### PR TITLE
Add script to parse race XML and generated parsed file

### DIFF
--- a/parse_races.py
+++ b/parse_races.py
@@ -1,0 +1,141 @@
+import xml.etree.ElementTree as ET
+import re
+
+def format_xml(element):
+    """Return a pretty-printed XML string for the Element."""
+    # This is a simple version. For more complex pretty printing, lxml might be better.
+    from xml.dom import minidom
+    rough_string = ET.tostring(element, 'utf-8')
+    reparsed = minidom.parseString(rough_string)
+    return reparsed.toprettyxml(indent="  ")
+
+def parse_races(input_filepath, output_filepath):
+    """
+    Parses the races XML file according to the glossary and writes a new XML file.
+    """
+    try:
+        input_tree = ET.parse(input_filepath)
+        input_root = input_tree.getroot()
+    except ET.ParseError as e:
+        print(f"Error parsing XML file {input_filepath}: {e}")
+        return
+    except FileNotFoundError:
+        print(f"Error: Input file not found {input_filepath}")
+        return
+
+    output_root = ET.Element(input_root.tag)
+    if input_root.get('version'):
+        output_root.set('version', input_root.get('version'))
+    if input_root.get('auto_indent'):
+        output_root.set('auto_indent', input_root.get('auto_indent'))
+
+    for input_race_element in input_root.findall('race'):
+        output_race_element = ET.SubElement(output_root, 'race')
+
+        # Helper function to directly copy simple elements if they exist
+        def copy_simple_element(parent_in, parent_out, tag_name):
+            element = parent_in.find(tag_name)
+            if element is not None:
+                new_element = ET.SubElement(parent_out, tag_name, element.attrib)
+                new_element.text = element.text
+                # Also copy any children of this simple element (e.g. <source> might have attributes on main tag and text)
+                for sub_element in element: # This is not standard for truly 'simple' tags but good for <source>
+                    new_sub_element = ET.SubElement(new_element, sub_element.tag, sub_element.attrib)
+                    new_sub_element.text = sub_element.text
+
+
+        # Parse and add top-level elements according to glossary
+        # <name>
+        copy_simple_element(input_race_element, output_race_element, 'name')
+
+        # <source page="[numero]">[NombreLibroFuente]</source>
+        source_element = input_race_element.find('source')
+        if source_element is not None:
+            # The source tag in races-phb24.xml has page as an attribute and text for the book name.
+            # This matches the glossary: <source page="[numero]">[NombreLibroFuente]</source>
+            new_source = ET.SubElement(output_race_element, 'source', source_element.attrib)
+            new_source.text = source_element.text
+
+        # <size_summary code="[S|M|L|T|G|H]"/>
+        size_summary_element = input_race_element.find('size_summary')
+        if size_summary_element is not None:
+            ET.SubElement(output_race_element, 'size_summary', size_summary_element.attrib)
+            # size_summary should be an empty tag with attributes only, text is not expected.
+
+        # <speed base="[numero_pies]"/>
+        speed_element = input_race_element.find('speed')
+        if speed_element is not None:
+            ET.SubElement(output_race_element, 'speed', speed_element.attrib)
+            # speed should be an empty tag with attributes only.
+
+        # <spellcasting_ability default="[AbilityName]" allow_choice="[true|false]"/> (Optional)
+        spellcasting_ability_element = input_race_element.find('spellcasting_ability')
+        if spellcasting_ability_element is not None:
+            ET.SubElement(output_race_element, 'spellcasting_ability', spellcasting_ability_element.attrib)
+            # This should also be an empty tag with attributes.
+
+        # Placeholder for <description_text> if it were a direct child,
+        # but in races-phb24.xml it's usually a <trait category="description">
+        # copy_simple_element(input_race_element, output_race_element, 'description_text')
+
+
+        # Implement parsing for <trait> elements
+        for input_trait_element in input_race_element.findall('trait'):
+            output_trait_element = ET.SubElement(output_race_element, 'trait', input_trait_element.attrib)
+
+            # Define a recursive function to copy/transform elements based on glossary
+            # This function will be expanded as we identify specific transformations needed
+            def process_element(input_el, output_el_parent):
+                # Create the new element in the output tree
+                # Attributes are copied directly. The glossary doesn't ask to change attributes of existing tags,
+                # but rather ensure the correct tags and structures are used.
+                output_el = ET.SubElement(output_el_parent, input_el.tag, input_el.attrib)
+                output_el.text = input_el.text
+                output_el.tail = input_el.tail # Preserve tail text for mixed content
+
+                # Recursively process children
+                for child_input_el in input_el:
+                    process_element(child_input_el, output_el)
+
+            # Process each child of the current input_trait_element
+            for child_input_el in input_trait_element:
+                # Here, we could add specific logic if child_input_el.tag needs transformation
+                # based on the glossary. For example, if an <effect_old_format> needed to become <effect type="...">.
+                # For now, we assume `races-phb24.xml` is already *using* the correct tag names like <effect>, <choice>,
+                # and the main task is to ensure their structure and attributes are preserved and correctly nested.
+                # The glossary is more about *which* tags to use and *how* they should be structured, rather than
+                # wholesale renaming of tags that are already close to the target.
+
+                # Example: If glossary required a specific attribute to be present on an <effect> tag,
+                # we could check and add it here.
+                # if child_input_el.tag == 'effect':
+                #     if 'type' not in child_input_el.attrib:
+                #         # This would be a case for error or applying a default based on glossary
+                #         pass
+
+                process_element(child_input_el, output_trait_element)
+
+
+    # Write the output XML file
+    try:
+        # Using ElementTree.write for basic output, then pretty-printing
+        # ET.indent(output_root) # Available in Python 3.9+ for pretty printing
+        # tree = ET.ElementTree(output_root)
+        # tree.write(output_filepath, encoding='utf-8', xml_declaration=True)
+
+        # Using custom formatter for pretty print
+        pretty_xml_string = format_xml(output_root)
+        with open(output_filepath, "w", encoding="utf-8") as f:
+            f.write(pretty_xml_string)
+        print(f"Successfully parsed races to {output_filepath}")
+    except IOError as e:
+        print(f"Error writing XML file {output_filepath}: {e}")
+
+
+if __name__ == "__main__":
+    # Path to the input races XML file
+    input_races_file = "01_Core/01_Players_Handbook_2024/races-phb24.xml"
+    # Path for the output (parsed) XML file
+    output_races_file = "races-phb24-parsed.xml"
+
+    parse_races(input_races_file, output_races_file)

--- a/races-phb24-parsed.xml
+++ b/races-phb24-parsed.xml
@@ -1,0 +1,1581 @@
+<?xml version="1.0" ?>
+<compendium version="5" auto_indent="NO">
+  <race>
+    <name>Aasimar [2024]</name>
+    <source page="186">Player's Handbook 2024</source>
+    <size_summary code="M"/>
+    <speed base="30"/>
+    <spellcasting_ability default="Charisma"/>
+    <trait category="description">
+      <name>Description</name>
+
+
+      <text>Aasimar (pronounced AH-sih-mar) are mortals who carry a spark of the Upper Planes within their souls. Whether descended from an angelic being or infused with celestial power, they can fan that spark to bring light, healing, and heavenly fury.
+	Aasimar can arise among any population of mortals. They resemble their parents, but they live for up to 160 years and have features that hint at their celestial heritage, such as metallic freckles, luminous eyes, a halo, or the skin color of an angel (silver, opalescent green, or coppery red). These features start subtle and become obvious when the aasimar learns to reveal their full celestial nature.</text>
+
+
+    </trait>
+    <trait category="core">
+      <name>Creature Type</name>
+
+
+      <text>Humanoid</text>
+
+
+    </trait>
+    <trait category="core" name="Size">
+      <text>Aasimar can be Medium (about 4-7 feet tall) or Small (about 2-4 feet tall).</text>
+
+
+      <choice name="SizeSelection" count="1">
+
+
+        <option name="Medium" description_text="about 4-7 feet tall">
+
+
+          <effect type="SizeCategory" value="Medium"/>
+
+
+        </option>
+
+
+        <option name="Small" description_text="about 2-4 feet tall">
+
+
+          <effect type="SizeCategory" value="Small"/>
+
+
+        </option>
+
+
+      </choice>
+
+
+      <note text="This choice is made when you select this species."/>
+
+
+    </trait>
+    <trait category="species" name="Celestial Resistance">
+      <text>You have Resistance to Necrotic damage and Radiant damage.</text>
+
+
+      <effect type="Resistance" damage_types="Necrotic,Radiant"/>
+
+
+    </trait>
+    <trait category="species" name="Darkvision">
+      <text>You have Darkvision with a range of 60 feet.</text>
+
+
+      <effect type="Sense" name="Darkvision" range="60"/>
+
+
+    </trait>
+    <trait category="species" name="Healing Hands">
+      <text>As a Magic action, you touch a creature and roll a number of d4s equal to your Proficiency Bonus. The creature regains a number of Hit Points equal to the total rolled. Once you use this trait, you can't use it again until you finish a Long Rest.</text>
+
+
+      <action type="MagicAction"/>
+
+
+      <effect type="Heal" value_formula="ProficiencyBonusd4" target="creature_touched">
+
+
+        <note text="Roll a number of d4s equal to your Proficiency Bonus. The creature regains HP equal to the total."/>
+
+
+      </effect>
+
+
+      <uses fixed="1">
+
+
+        <recharge type="LR"/>
+
+
+      </uses>
+
+
+    </trait>
+    <trait category="species" name="Light Bearer">
+      <text>You know the Light cantrip. Charisma is your spellcasting ability for it.</text>
+
+
+      <grants_spell_learning type="Cantrip" spell_known="Light" spellcasting_ability_fixed="Charisma"/>
+
+
+    </trait>
+    <trait category="species" name="Celestial Revelation" gained_at_character_level="3">
+      <text>When you reach character level 3, you can transform as a Bonus Action using one of the options below (choose the option each time you transform). The transformation lasts for 1 minute or until you end it (no action required). Once you transform, you can't do so again until you finish a Long Rest.
+	Once on each of your turns before the transformation ends, you can deal extra damage to one target when you deal damage to it with an attack or a spell. The extra damage equals your Proficiency Bonus, and the extra damage's type is either Necrotic for Necrotic Shroud or Radiant for Heavenly Wings and Inner Radiance.</text>
+
+
+      <action type="BonusAction" to_assume_form="true"/>
+
+
+      <duration description="1_minute" ends_early_if="dismissed_no_action"/>
+
+
+      <uses fixed="1">
+
+
+        <recharge type="LR"/>
+
+
+      </uses>
+
+
+      <choice name="CelestialRevelationForm" count="1" trigger="each_time_you_transform">
+
+
+        <option name="Heavenly Wings">
+
+
+          <text>Two spectral wings sprout from your back temporarily. Until the transformation ends, you have a Fly Speed equal to your Speed.</text>
+
+
+          <effect type="Speed" speed_type="Fly" value_formula="current_Speed"/>
+
+
+          <effect type="ExtraDamage" value_formula="ProficiencyBonus" damage_type="Radiant" timing="once_on_each_of_your_turns_on_attack_or_spell_hit"/>
+
+
+        </option>
+
+
+        <option name="Inner Radiance">
+
+
+          <text>Searing light temporarily radiates from your eyes and mouth. For the duration, you shed Bright Light in a 10-foot radius and Dim Light for an additional 10 feet, and at the end of each of your turns, each creature within 10 feet of you takes Radiant damage equal to your Proficiency Bonus.</text>
+
+
+          <effect type="CreateArea" name="RadiantLight" shape="Emanation" radius="10_feet_bright_plus_10_feet_dim"/>
+
+
+          <effect type="Damage" damage_type="Radiant" value_formula="ProficiencyBonus" target_description="each_creature_within_10_feet_of_you" timing="at_the_end_of_each_of_your_turns"/>
+
+
+          <effect type="ExtraDamage" value_formula="ProficiencyBonus" damage_type="Radiant" timing="once_on_each_of_your_turns_on_attack_or_spell_hit"/>
+
+
+        </option>
+
+
+        <option name="Necrotic Shroud">
+
+
+          <text>Your eyes briefly become pools of darkness, and flightless wings sprout from your back temporarily. Creatures other than your allies within 10 feet of you must succeed on a Charisma saving throw (DC 8 plus your Charisma modifier and Proficiency Bonus) or have the Frightened condition until the end of your next turn.</text>
+
+
+          <effect type="Condition" name="Frightened" target="creatures_other_than_allies_within_10_feet" duration="until_end_of_your_next_turn">
+
+
+            <save_type>CHA</save_type>
+
+
+            <save_dc formula="8+CHA_modifier+ProficiencyBonus"/>
+
+
+            <save_effect text_override="no_condition_on_success"/>
+
+
+          </effect>
+
+
+          <effect type="ExtraDamage" value_formula="ProficiencyBonus" damage_type="Necrotic" timing="once_on_each_of_your_turns_on_attack_or_spell_hit"/>
+
+
+        </option>
+
+
+      </choice>
+
+
+    </trait>
+  </race>
+  <race>
+    <name>Dragonborn [2024]</name>
+    <source page="187">Player's Handbook 2024</source>
+    <size_summary code="M"/>
+    <speed base="30"/>
+    <trait category="description">
+      <name>Description</name>
+
+
+      <text>The ancestors of dragonborn hatched from the eggs of chromatic and metallic dragons. One story holds that these eggs were blessed by the dragon gods Bahamut and Tiamat, who wanted to populate the multiverse with people created in their image. Another story claims that dragons created the first dragonborn without the gods' blessings. Whatever their origin, dragonborn have made homes for themselves on the Material Plane.
+	Dragonborn look like wingless, bipedal dragons-scaly, bright-eyed, and thick-boned with horns on their heads-and their coloration and other features are reminiscent of their draconic ancestors.</text>
+
+
+    </trait>
+    <trait category="core">
+      <name>Creature Type</name>
+
+
+      <text>Humanoid</text>
+
+
+    </trait>
+    <trait category="core" name="Size">
+      <text>Medium (about 5-7 feet tall)</text>
+
+
+      <effect type="SizeCategory" value="Medium" description_text="about 5-7 feet tall"/>
+
+
+    </trait>
+    <trait category="ancestry_choice" name="Draconic Ancestry">
+      <text>Your lineage stems from a dragon progenitor. Choose the kind of dragon from the Draconic Ancestors table. Your choice affects your Breath Weapon and Damage Resistance traits as well as your appearance.
+
+Draconic Ancestry:
+Dragon | Damage Type
+Black | Acid
+Blue | Lightning
+Brass | Fire
+Bronze | Lightning
+Copper | Acid
+Gold | Fire
+Green | Poison
+Red | Fire
+Silver | Cold
+White | Cold</text>
+
+
+      <choice name="DraconicAncestorSelection" count="1">
+
+
+        <option name="Black Dragon">
+
+
+          <effect type="DamageTypeAssociation" value="Acid" for_trait="Breath Weapon,Damage Resistance"/>
+
+
+        </option>
+
+
+        <option name="Blue Dragon">
+
+
+          <effect type="DamageTypeAssociation" value="Lightning" for_trait="Breath Weapon,Damage Resistance"/>
+
+
+        </option>
+
+
+        <option name="Brass Dragon">
+
+
+          <effect type="DamageTypeAssociation" value="Fire" for_trait="Breath Weapon,Damage Resistance"/>
+
+
+        </option>
+
+
+        <option name="Bronze Dragon">
+
+
+          <effect type="DamageTypeAssociation" value="Lightning" for_trait="Breath Weapon,Damage Resistance"/>
+
+
+        </option>
+
+
+        <option name="Copper Dragon">
+
+
+          <effect type="DamageTypeAssociation" value="Acid" for_trait="Breath Weapon,Damage Resistance"/>
+
+
+        </option>
+
+
+        <option name="Gold Dragon">
+
+
+          <effect type="DamageTypeAssociation" value="Fire" for_trait="Breath Weapon,Damage Resistance"/>
+
+
+        </option>
+
+
+        <option name="Green Dragon">
+
+
+          <effect type="DamageTypeAssociation" value="Poison" for_trait="Breath Weapon,Damage Resistance"/>
+
+
+        </option>
+
+
+        <option name="Red Dragon">
+
+
+          <effect type="DamageTypeAssociation" value="Fire" for_trait="Breath Weapon,Damage Resistance"/>
+
+
+        </option>
+
+
+        <option name="Silver Dragon">
+
+
+          <effect type="DamageTypeAssociation" value="Cold" for_trait="Breath Weapon,Damage Resistance"/>
+
+
+        </option>
+
+
+        <option name="White Dragon">
+
+
+          <effect type="DamageTypeAssociation" value="Cold" for_trait="Breath Weapon,Damage Resistance"/>
+
+
+        </option>
+
+
+      </choice>
+
+
+    </trait>
+    <trait category="species" name="Breath Weapon">
+      <text>When you take the Attack action on your turn, you can replace one of your attacks with an exhalation of magical energy in either a 15-foot Cone or a 30-foot Line that is 5 feet wide (choose the shape each time). Each creature in that area must make a Dexterity saving throw (DC 8 plus your Constitution modifier and Proficiency Bonus). On a failed save, a creature takes 1d10 damage of the type determined by your Draconic Ancestry trait. On a successful save, a creature takes half as much damage. This damage increases by 1d10 when you reach character levels 5 (2d10), 11 (3d10), and 17 (4d10).</text>
+
+
+      <action type="Special" description="Can replace one attack when taking Attack action"/>
+
+
+      <choice name="BreathShape" count="1">
+
+
+        <option name="Cone">
+
+
+          <effect type="Damage" damage_type_ref="DraconicAncestry" value_dice="1d10" area_shape="15-foot_Cone">
+
+
+            <save_type>DEX</save_type>
+
+
+            <save_dc formula="8+CON_modifier+ProficiencyBonus"/>
+
+
+            <save_effect value="half_damage"/>
+
+
+            <scaling level="5" dice="2d10"/>
+
+
+            <scaling level="11" dice="3d10"/>
+
+
+            <scaling level="17" dice="4d10"/>
+
+
+          </effect>
+
+
+        </option>
+
+
+        <option name="Line">
+
+
+          <effect type="Damage" damage_type_ref="DraconicAncestry" value_dice="1d10" area_shape="30-foot_Line_5_feet_wide">
+
+
+            <save_type>DEX</save_type>
+
+
+            <save_dc formula="8+CON_modifier+ProficiencyBonus"/>
+
+
+            <save_effect value="half_damage"/>
+
+
+            <scaling level="5" dice="2d10"/>
+
+
+            <scaling level="11" dice="3d10"/>
+
+
+            <scaling level="17" dice="4d10"/>
+
+
+          </effect>
+
+
+        </option>
+
+
+      </choice>
+
+
+      <uses attribute="ProficiencyBonus">
+
+
+        <recharge type="LR"/>
+
+
+      </uses>
+
+
+    </trait>
+    <trait category="species" name="Damage Resistance">
+      <text>You have Resistance to the damage type determined by your Draconic Ancestry trait.</text>
+
+
+      <effect type="Resistance" damage_types_ref="DraconicAncestry"/>
+
+
+    </trait>
+    <trait category="species" name="Darkvision">
+      <text>You have Darkvision with a range of 60 feet.</text>
+
+
+      <effect type="Sense" name="Darkvision" range="60"/>
+
+
+    </trait>
+    <trait category="species" name="Draconic Flight" gained_at_character_level="5">
+      <text>When you reach character level 5, you can channel draconic magic to give yourself temporary flight. As a Bonus Action, you sprout spectral wings on your back that last for 10 minutes or until you retract the wings (no action required) or have the Incapacitated condition. During that time, you have a Fly Speed equal to your Speed. Your wings appear to be made of the same energy as your Breath Weapon.</text>
+
+
+      <action type="BonusAction" to_assume_form="true"/>
+
+
+      <duration description="10_minutes" ends_early_if="dismissed_no_action,Incapacitated_condition"/>
+
+
+      <effect type="Speed" speed_type="Fly" value_formula="current_Speed"/>
+
+
+      <note text="Wings appear to be made of the same energy as your Breath Weapon."/>
+
+
+      <uses fixed="1">
+
+
+        <recharge type="LR"/>
+
+
+      </uses>
+
+
+    </trait>
+  </race>
+  <race>
+    <name>Dwarf [2024]</name>
+    <source page="188">Player's Handbook 2024</source>
+    <size_summary code="M"/>
+    <speed base="30"/>
+    <trait category="description" name="Description">
+      <text>Dwarves were raised from the earth in the elder days by a deity of the forge. Called by various names on different worlds -Moradin, Reorx, and others- that god gave dwarves an affinity for stone and metal and for living underground. The god also made them resilient like the mountains, with a life span of about 350 years.
+	Squat and often bearded, the original dwarves carved cities and strongholds into mountainsides and under the earth. Their oldest legends tell of conflicts with the monsters of mountaintops and the Underdark, whether those monsters were towering giants or subterranean horrors. Inspired by those tales, dwarves of any culture often sing of valorous deeds-especially of the little overcoming the mighty.
+	On some worlds in the multiverse, the first settlements of dwarves were built in hills or mountains, and the families who trace their ancestry to those settlements call themselves hill dwarves or mountain dwarves, respectively. The Greyhawk and Dragonlance settings have such communities.</text>
+
+
+    </trait>
+    <trait category="core" name="Creature Type">
+      <text>Humanoid</text>
+
+
+    </trait>
+    <trait category="core" name="Size">
+      <text>Medium (about 4-5 feet tall)</text>
+
+
+      <effect type="SizeCategory" value="Medium" description_text="about 4-5 feet tall"/>
+
+
+    </trait>
+    <trait category="species" name="Darkvision">
+      <text>You have Darkvision with a range of 120 feet.</text>
+
+
+      <effect type="Sense" name="Darkvision" range="120"/>
+
+
+    </trait>
+    <trait category="species" name="Dwarven Resilience">
+      <text>You have Resistance to Poison damage. You also have Advantage on saving throws you make to avoid or end the Poisoned condition.</text>
+
+
+      <effect type="Resistance" damage_types="Poison"/>
+
+
+      <effect type="Advantage" on="saving_throws_to_avoid_or_end_Poisoned_condition"/>
+
+
+    </trait>
+    <trait category="species" name="Dwarven Toughness">
+      <text>Your Hit Point maximum increases by 1, and it increases by 1 again whenever you gain a level.</text>
+
+
+      <effect type="HitPointMaximumIncrease" value_formula="max(1,character_level)" description="Increases by 1, and by 1 again per level."/>
+
+
+    </trait>
+    <trait category="species" name="Stonecunning">
+      <text>As a Bonus Action, you gain Tremorsense with a range of 60 feet for 10 minutes. You must be on a stone surface or touching a stone surface to use this Tremorsense. The stone can be natural or worked.</text>
+
+
+      <action type="BonusAction"/>
+
+
+      <effect type="Sense" name="Tremorsense" range="60" duration="10_minutes">
+
+
+        <condition text="Must be on a stone surface or touching a stone surface. Stone can be natural or worked."/>
+
+
+      </effect>
+
+
+      <uses attribute="ProficiencyBonus">
+
+
+        <recharge type="LR"/>
+
+
+      </uses>
+
+
+    </trait>
+  </race>
+  <race>
+    <name>Elf, Drow [2024]</name>
+    <source page="189">Player's Handbook 2024</source>
+    <size_summary code="M"/>
+    <speed base="30"/>
+    <trait category="description" name="Description">
+      <text>Created by the god Corellon, the first elves could change their forms at will. They lost this ability when Corellon cursed them for plotting with the deity Lolth, who tried and failed to usurp Corellon's dominion. When Lolth was cast into the Abyss, most elves renounced her and earned Corellon's forgiveness, but that which Corellon had taken from them was lost forever.
+	No longer able to shapeshift at will, the elves retreated to the Feywild, where their sorrow was deepened by that plane's influence. Over time, curiosity led many of them to explore other planes of existence, including worlds in the Material Plane.
+	Elves have pointed ears and lack facial and body hair. They live for around 750 years, and they don't sleep but instead enter a trance when they need to rest. In that state, they remain aware of their surroundings while immersing themselves in memories and meditations.
+	An environment subtly transforms elves after they inhabit it for a millennium or more, and it grants them certain kinds of magic. Drow, high elves, and wood elves are examples of elves who have been transformed thus.
+
+Drow typically dwell in the Underdark and have been shaped by it. Some drow individuals and societies avoid the Underdark altogether yet car ry its magic. In the Eberron setting. for example. drow dwell in rainforests and cyclopean ruins on the continent of Xen'drik.</text>
+
+
+    </trait>
+    <trait category="core" name="Creature Type">
+      <text>Humanoid</text>
+
+
+    </trait>
+    <trait category="core" name="Size">
+      <text>Medium (about 5-6 feet tall)</text>
+
+
+      <effect type="SizeCategory" value="Medium" description_text="about 5-6 feet tall"/>
+
+
+    </trait>
+    <trait category="species" name="Darkvision">
+      <text>You have Darkvision with a range of 60 feet. (Drow Lineage increases this)</text>
+
+
+      <effect type="Sense" name="Darkvision" range="60"/>
+
+
+    </trait>
+    <trait category="lineage" name="Drow Lineage">
+      <text>The range of your Darkvision increases to 120 feet. You also know the Dancing Lights cantrip. Intelligence, Wisdom, or Charisma is your spellcasting ability for the spells you cast with this trait (choose the ability when you select the lineage).</text>
+
+
+      <effect type="Sense" name="Darkvision" range="120" upgrades_existing="true"/>
+
+
+      <grants_spell_learning type="Cantrip" spell_known="Dancing Lights" spellcasting_ability_choice="Intelligence|Wisdom|Charisma" count="1"/>
+
+
+      <grants_spell_learning type="Spell" spell_known="Faerie Fire" gained_at_character_level="3" spellcasting_ability_choice_ref="Drow Lineage" free_casts_per_rest="LongRest" count="1"/>
+
+
+      <grants_spell_learning type="Spell" spell_known="Darkness" gained_at_character_level="5" spellcasting_ability_choice_ref="Drow Lineage" free_casts_per_rest="LongRest" count="1"/>
+
+
+    </trait>
+    <trait category="species" name="Fey Ancestry">
+      <text>You have Advantage on saving throws you make to avoid or end the Charmed condition.</text>
+
+
+      <effect type="Advantage" on="saving_throws_to_avoid_or_end_Charmed_condition"/>
+
+
+    </trait>
+    <trait category="species" name="Keen Senses">
+      <text>You have proficiency in the Insight, Perception, or Survival skill.</text>
+
+
+      <grants_proficiency type="Skill" choice_from_list="Insight|Perception|Survival" count="1"/>
+
+
+    </trait>
+    <trait category="species" name="Trance">
+      <text>You don't need to sleep, and magic can't put you to sleep. You can finish a Long Rest in 4 hours if you spend those hours in a trancelike meditation, during which you retain consciousness.</text>
+
+
+      <modifies_rule rule_name="SleepRequirement" effect_description="Don't need to sleep."/>
+
+
+      <modifies_rule rule_name="MagicalSleep" effect_description="Magic can't put you to sleep."/>
+
+
+      <modifies_rule rule_name="LongRestDuration" new_value="4_hours_if_trancing"/>
+
+
+      <note text="During trance, you retain consciousness."/>
+
+
+    </trait>
+  </race>
+  <race>
+    <name>Elf, High [2024]</name>
+    <source page="189">Player's Handbook 2024</source>
+    <size_summary code="M"/>
+    <speed base="30"/>
+    <trait category="description" name="Description">
+      <text>Created by the god Corellon, the first elves could change their forms at will. They lost this ability when Corellon cursed them for plotting with the deity Lolth, who tried and failed to usurp Corellon's dominion. When Lolth was cast into the Abyss, most elves renounced her and earned Corellon's forgiveness, but that which Corellon had taken from them was lost forever.
+	No longer able to shapeshift at will, the elves retreated to the Feywild, where their sorrow was deepened by that plane's influence. Over time, curiosity led many of them to explore other planes of existence, including worlds in the Material Plane.
+	Elves have pointed ears and lack facial and body hair. They live for around 750 years, and they don't sleep but instead enter a trance when they need to rest. In that state, they remain aware of their surroundings while immersing themselves in memories and meditations.
+	An environment subtly transforms elves after they inhabit it for a millennium or more, and it grants them certain kinds of magic. Drow, high elves, and wood elves are examples of elves who have been transformed thus.
+
+High elves have been infused with the magic of crossings between the Feywild and the Material Plane. On some worlds. high elves refer to themselves by other names. For example. they call themselves sun or moon elves in the Forgotten Realms setting, Silvanesti and Qualinesti in the Dragon lance setting, and Aereni in the Eberron setting.</text>
+
+
+    </trait>
+    <trait category="core" name="Creature Type">
+      <text>Humanoid</text>
+
+
+    </trait>
+    <trait category="core" name="Size">
+      <text>Medium (about 5-6 feet tall)</text>
+
+
+      <effect type="SizeCategory" value="Medium" description_text="about 5-6 feet tall"/>
+
+
+    </trait>
+    <trait category="species" name="Darkvision">
+      <text>You have Darkvision with a range of 60 feet.</text>
+
+
+      <effect type="Sense" name="Darkvision" range="60"/>
+
+
+    </trait>
+    <trait category="lineage" name="High Elf Lineage">
+      <text>You know the Prestidigitation cantrip. Whenever you finish a Long Rest, you can replace that cantrip with a different cantrip from the Wizard spell list. Intelligence, Wisdom, or Charisma is your spellcasting ability for the spells you cast with this trait (choose the ability when you select the lineage).</text>
+
+
+      <grants_spell_learning type="Cantrip" spell_known="Prestidigitation" spellcasting_ability_choice="Intelligence|Wisdom|Charisma" count="1" can_replace_on_long_rest="true" replacement_spell_list="Wizard"/>
+
+
+      <grants_spell_learning type="Spell" spell_known="Detect Magic" gained_at_character_level="3" spellcasting_ability_choice_ref="High Elf Lineage" free_casts_per_rest="LongRest" count="1"/>
+
+
+      <grants_spell_learning type="Spell" spell_known="Misty Step" gained_at_character_level="5" spellcasting_ability_choice_ref="High Elf Lineage" free_casts_per_rest="LongRest" count="1"/>
+
+
+    </trait>
+    <trait category="species" name="Fey Ancestry">
+      <text>You have Advantage on saving throws you make to avoid or end the Charmed condition.</text>
+
+
+      <effect type="Advantage" on="saving_throws_to_avoid_or_end_Charmed_condition"/>
+
+
+    </trait>
+    <trait category="species" name="Keen Senses">
+      <text>You have proficiency in the Insight, Perception, or Survival skill.</text>
+
+
+      <grants_proficiency type="Skill" choice_from_list="Insight|Perception|Survival" count="1"/>
+
+
+    </trait>
+    <trait category="species" name="Trance">
+      <text>You don't need to sleep, and magic can't put you to sleep. You can finish a Long Rest in 4 hours if you spend those hours in a trancelike meditation, during which you retain consciousness.</text>
+
+
+      <modifies_rule rule_name="SleepRequirement" effect_description="Don't need to sleep."/>
+
+
+      <modifies_rule rule_name="MagicalSleep" effect_description="Magic can't put you to sleep."/>
+
+
+      <modifies_rule rule_name="LongRestDuration" new_value="4_hours_if_trancing"/>
+
+
+      <note text="During trance, you retain consciousness."/>
+
+
+    </trait>
+  </race>
+  <race>
+    <name>Elf, Wood [2024]</name>
+    <source page="189">Player's Handbook 2024</source>
+    <size_summary code="M"/>
+    <speed base="35"/>
+    <trait category="description" name="Description">
+      <text>Created by the god Corellon, the first elves could change their forms at will. They lost this ability when Corellon cursed them for plotting with the deity Lolth, who tried and failed to usurp Corellon's dominion. When Lolth was cast into the Abyss, most elves renounced her and earned Corellon's forgiveness, but that which Corellon had taken from them was lost forever.
+	No longer able to shapeshift at will, the elves retreated to the Feywild, where their sorrow was deepened by that plane's influence. Over time, curiosity led many of them to explore other planes of existence, including worlds in the Material Plane.
+	Elves have pointed ears and lack facial and body hair. They live for around 750 years, and they don't sleep but instead enter a trance when they need to rest. In that state, they remain aware of their surroundings while immersing themselves in memories and meditations.
+	An environment subtly transforms elves after they inhabit it for a millennium or more, and it grants them certain kinds of magic. Drow, high elves, and wood elves are examples of elves who have been transformed thus.
+
+Wood elves carry the magic of primeval forests within themselves. They are known by many other names, including wild elves, green elves, and forest elves. Grugach are reclusive wood elves of the Greyhawk setting, while the Kagones and the Tairnadal are wood elves of the Dragon lance and Eberron settings. respectively.</text>
+
+
+    </trait>
+    <trait category="core" name="Creature Type">
+      <text>Humanoid</text>
+
+
+    </trait>
+    <trait category="core" name="Size">
+      <text>Medium (about 5-6 feet tall)</text>
+
+
+      <effect type="SizeCategory" value="Medium" description_text="about 5-6 feet tall"/>
+
+
+    </trait>
+    <trait category="species" name="Darkvision">
+      <text>You have Darkvision with a range of 60 feet.</text>
+
+
+      <effect type="Sense" name="Darkvision" range="60"/>
+
+
+    </trait>
+    <trait category="lineage" name="Wood Elf Lineage">
+      <text>Your Speed increases to 35 feet. You also know the Druidcraft cantrip. Intelligence, Wisdom, or Charisma is your spellcasting ability for the spells you cast with this trait (choose the ability when you select the lineage).</text>
+
+
+      <effect type="SpeedIncrease" value="5" new_total_speed="35" note="Base speed becomes 35 feet."/>
+
+
+      <grants_spell_learning type="Cantrip" spell_known="Druidcraft" spellcasting_ability_choice="Intelligence|Wisdom|Charisma" count="1"/>
+
+
+      <grants_spell_learning type="Spell" spell_known="Longstrider" gained_at_character_level="3" spellcasting_ability_choice_ref="Wood Elf Lineage" free_casts_per_rest="LongRest" count="1"/>
+
+
+      <grants_spell_learning type="Spell" spell_known="Pass without Trace" gained_at_character_level="5" spellcasting_ability_choice_ref="Wood Elf Lineage" free_casts_per_rest="LongRest" count="1"/>
+
+
+    </trait>
+    <trait category="species" name="Fey Ancestry">
+      <text>You have Advantage on saving throws you make to avoid or end the Charmed condition.</text>
+
+
+      <effect type="Advantage" on="saving_throws_to_avoid_or_end_Charmed_condition"/>
+
+
+    </trait>
+    <trait category="species" name="Keen Senses">
+      <text>You have proficiency in the Insight, Perception, or Survival skill.</text>
+
+
+      <grants_proficiency type="Skill" choice_from_list="Insight|Perception|Survival" count="1"/>
+
+
+    </trait>
+    <trait category="species" name="Trance">
+      <text>You don't need to sleep, and magic can't put you to sleep. You can finish a Long Rest in 4 hours if you spend those hours in a trancelike meditation, during which you retain consciousness.</text>
+
+
+      <modifies_rule rule_name="SleepRequirement" effect_description="Don't need to sleep."/>
+
+
+      <modifies_rule rule_name="MagicalSleep" effect_description="Magic can't put you to sleep."/>
+
+
+      <modifies_rule rule_name="LongRestDuration" new_value="4_hours_if_trancing"/>
+
+
+      <note text="During trance, you retain consciousness."/>
+
+
+    </trait>
+  </race>
+  <race>
+    <name>Gnome, Forest [2024]</name>
+    <source page="191">Player's Handbook 2024</source>
+    <size_summary code="S"/>
+    <speed base="30"/>
+    <trait category="description" name="Description">
+      <text>Gnomes are magical folk created by gods of invention, illusions, and life underground. The earliest gnomes were seldom seen by other folk due to the gnomes' secretive nature and their propensity for living in forests and burrows. What they lacked in size, they made up for in cleverness. They confounded predators with traps and labyrinthine tunnels. They also learned magic from gods like Garl Glittergold, Baervan Wildwanderer, and Baravar Cloakshadow, who visited them in disguise. That magic eventually created the lineages of forest gnomes and rock gnomes.
+	Gnomes are petite folk with big eyes and pointed ears, who live around 425 years. Many gnomes like the feeling of a roof over their head, even if that &quot;roof&quot; is nothing more than a hat.</text>
+
+
+    </trait>
+    <trait category="core" name="Creature Type">
+      <text>Humanoid</text>
+
+
+    </trait>
+    <trait category="core" name="Size">
+      <text>Small (about 3-4 feet tall)</text>
+
+
+      <effect type="SizeCategory" value="Small" description_text="about 3-4 feet tall"/>
+
+
+    </trait>
+    <trait category="species" name="Darkvision">
+      <text>You have Darkvision with a range of 60 feet.</text>
+
+
+      <effect type="Sense" name="Darkvision" range="60"/>
+
+
+    </trait>
+    <trait category="species" name="Gnomish Cunning">
+      <text>You have Advantage on Intelligence, Wisdom, and Charisma saving throws.</text>
+
+
+      <effect type="Advantage" on="Intelligence_saving_throws"/>
+
+
+      <effect type="Advantage" on="Wisdom_saving_throws"/>
+
+
+      <effect type="Advantage" on="Charisma_saving_throws"/>
+
+
+    </trait>
+    <trait category="lineage" name="Forest Lineage">
+      <text>You know the Minor Illusion cantrip. You also always have the Speak with Animals spell prepared. You can cast it without a spell slot a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest. You can also use any spell slots you have to cast the spell.</text>
+
+
+      <grants_spell_learning type="Cantrip" spell_known="Minor Illusion" spellcasting_ability_fixed="Intelligence"/>
+
+
+      <grants_spell_learning type="Spell" spell_known="Speak with Animals" always_prepared="true" spellcasting_ability_fixed="Intelligence" free_casts_per_rest="LongRest" count_formula="ProficiencyBonus" can_use_spell_slots="true"/>
+
+
+    </trait>
+  </race>
+  <race>
+    <name>Gnome, Rock [2024]</name>
+    <source page="191">Player's Handbook 2024</source>
+    <size_summary code="S"/>
+    <speed base="30"/>
+    <trait category="description" name="Description">
+      <text>Gnomes are magical folk created by gods of invention, illusions, and life underground. The earliest gnomes were seldom seen by other folk due to the gnomes' secretive nature and their propensity for living in forests and burrows. What they lacked in size, they made up for in cleverness. They confounded predators with traps and labyrinthine tunnels. They also learned magic from gods like Garl Glittergold, Baervan Wildwanderer, and Baravar Cloakshadow, who visited them in disguise. That magic eventually created the lineages of forest gnomes and rock gnomes.
+	Gnomes are petite folk with big eyes and pointed ears, who live around 425 years. Many gnomes like the feeling of a roof over their head, even if that &quot;roof&quot; is nothing more than a hat.</text>
+
+
+    </trait>
+    <trait category="core" name="Creature Type">
+      <text>Humanoid</text>
+
+
+    </trait>
+    <trait category="core" name="Size">
+      <text>Small (about 3-4 feet tall)</text>
+
+
+      <effect type="SizeCategory" value="Small" description_text="about 3-4 feet tall"/>
+
+
+    </trait>
+    <trait category="species" name="Darkvision">
+      <text>You have Darkvision with a range of 60 feet.</text>
+
+
+      <effect type="Sense" name="Darkvision" range="60"/>
+
+
+    </trait>
+    <trait category="species" name="Gnomish Cunning">
+      <text>You have Advantage on Intelligence, Wisdom, and Charisma saving throws.</text>
+
+
+      <effect type="Advantage" on="Intelligence_saving_throws"/>
+
+
+      <effect type="Advantage" on="Wisdom_saving_throws"/>
+
+
+      <effect type="Advantage" on="Charisma_saving_throws"/>
+
+
+    </trait>
+    <trait category="lineage" name="Rock Lineage">
+      <text>You know the Mending and Prestidigitation cantrips. In addition, you can spend 10 minutes casting Prestidigitation to create a Tiny clockwork device (AC 5, 1 HP), such as a toy, fire starter, or music box. When you create the device, you determine its function by choosing one effect from Prestidigitation; the device produces that effect whenever you or another creature takes a Bonus Action to activate it with a touch. If the chosen effect has options within it, you choose one of those options for the device when you create it. For example, if you choose the spell's ignite-extinguish effect, you determine whether the device ignites or extinguishes fire; the device doesn't do both. You can have three such devices in existence at a time, and each falls apart 8 hours after its creation or when you dismantle it with a touch as a Utilize action.</text>
+
+
+      <grants_spell_learning type="Cantrip" spell_known="Mending" spellcasting_ability_fixed="Intelligence"/>
+
+
+      <grants_spell_learning type="Cantrip" spell_known="Prestidigitation" spellcasting_ability_fixed="Intelligence"/>
+
+
+      <action_option name="Create Clockwork Device">
+
+
+        <action type="Special" duration="10_minutes_casting_Prestidigitation"/>
+
+
+        <effect description="Create a Tiny clockwork device (AC 5, 1 HP). Choose one effect from Prestidigitation for its function. Activated by Bonus Action touch. Device produces chosen effect (specific option if applicable). Max 3 devices. Lasts 8 hours or until dismantled (Utilize action)."/>
+
+
+        <note text="Example: If ignite-extinguish effect chosen, device either ignites OR extinguishes, not both."/>
+
+
+      </action_option>
+
+
+    </trait>
+  </race>
+  <race>
+    <name>Goliath [2024]</name>
+    <source page="192">Player's Handbook 2024</source>
+    <size_summary code="M"/>
+    <speed base="35"/>
+    <trait category="description" name="Description">
+      <text>Towering over most folk, goliaths are distant descendants of giants. Each goliath bears the favors of the first giants-favors that manifest in various supernatural boons, including the ability to quickly grow and temporarily approach the height of goliaths' gigantic kin.
+	Goliaths have physical characteristics that are reminiscent of the giants in their family lines. For example, some goliaths look like stone giants, while others resemble fire giants. Whatever giants they count as kin, goliaths have forged their own path in the multiverse-unencumbered by the internecine conflicts that have ravaged giantkind for ages-and seek heights above those reached by their ancestors.</text>
+
+
+    </trait>
+    <trait category="core" name="Creature Type">
+      <text>Humanoid</text>
+
+
+    </trait>
+    <trait category="core" name="Size">
+      <text>Medium (about 7-8 feet tall)</text>
+
+
+      <effect type="SizeCategory" value="Medium" description_text="about 7-8 feet tall"/>
+
+
+    </trait>
+    <trait category="ancestry_choice" name="Giant Ancestry">
+      <text>You are descended from Giants. Choose one of the following benefits- a supernatural boon from your ancestry; you can use the chosen benefit a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest.</text>
+
+
+      <uses attribute="ProficiencyBonus">
+
+
+        <recharge type="LR"/>
+
+
+      </uses>
+
+
+      <choice name="GiantAncestryBenefit" count="1">
+
+
+        <option name="Cloud's Jaunt (Cloud Giant)">
+
+
+          <text>As a Bonus Action, you magically teleport up to 30 feet to an unoccupied space you can see.</text>
+
+
+          <action type="BonusAction">
+
+
+            <effect type="Teleport" range="up_to_30_feet" destination="unoccupied_space_you_can_see"/>
+
+
+          </action>
+
+
+        </option>
+
+
+        <option name="Fire's Burn (Fire Giant)">
+
+
+          <text>When you hit a target with an attack roll and deal damage to it, you can also deal 1d10 Fire damage to that target.</text>
+
+
+          <trigger text="when_you_hit_a_target_with_an_attack_roll_and_deal_damage"/>
+
+
+          <effect type="ExtraDamage" damage_type="Fire" value_dice="1d10" target_description="that_target"/>
+
+
+        </option>
+
+
+        <option name="Frost's Chill (Frost Giant)">
+
+
+          <text>When you hit a target with an attack roll and deal damage to it, you can also deal 1d6 Cold damage to that target and reduce its Speed by 10 feet until the start of your next turn.</text>
+
+
+          <trigger text="when_you_hit_a_target_with_an_attack_roll_and_deal_damage"/>
+
+
+          <effect type="ExtraDamage" damage_type="Cold" value_dice="1d6" target_description="that_target"/>
+
+
+          <effect type="SpeedReduction" value="10" duration="until_start_of_your_next_turn" target_description="that_target"/>
+
+
+        </option>
+
+
+        <option name="Hill's Tumble (Hill Giant)">
+
+
+          <text>When you hit a Large or smaller creature with an attack roll and deal damage to it, you can give that target the Prone condition.</text>
+
+
+          <trigger text="when_you_hit_a_Large_or_smaller_creature_with_an_attack_roll_and_deal_damage"/>
+
+
+          <effect type="Condition" name="Prone" target="that_target"/>
+
+
+        </option>
+
+
+        <option name="Stone's Endurance (Stone Giant)">
+
+
+          <text>When you take damage, you can take a Reaction to roll 1d12. Add your Constitution modifier to the number rolled and reduce the damage by that total.</text>
+
+
+          <action type="Reaction" trigger="when_you_take_damage">
+
+
+            <effect type="DamageReduction" value_formula="1d12+CON_modifier"/>
+
+
+          </action>
+
+
+        </option>
+
+
+        <option name="Storm's Thunder (Storm Giant)">
+
+
+          <text>When you take damage from a creature within 60 feet of you, you can take a Reaction to deal 1d8 Thunder damage to that creature.</text>
+
+
+          <action type="Reaction" trigger="when_you_take_damage_from_a_creature_within_60_feet_of_you">
+
+
+            <effect type="Damage" damage_type="Thunder" value_dice="1d8" target_description="that_creature"/>
+
+
+          </action>
+
+
+        </option>
+
+
+      </choice>
+
+
+    </trait>
+    <trait category="species" name="Large Form" gained_at_character_level="5">
+      <text>Starting at character level 5, you can change your size to Large as a Bonus Action if you're in a big enough space. This transformation lasts for 10 minutes or until you end it (no action required). For that duration, you have Advantage on Strength checks, and your Speed increases by 10 feet. Once you use this trait, you can't use it again until you finish a Long Rest.</text>
+
+
+      <action type="BonusAction" to_assume_form="true"/>
+
+
+      <duration description="10_minutes" ends_early_if="dismissed_no_action"/>
+
+
+      <effect type="Transformation" new_size="Large" condition="if_in_big_enough_space"/>
+
+
+      <effect type="Advantage" on="Strength_checks" condition="while_in_Large_form"/>
+
+
+      <effect type="SpeedIncrease" value="10" condition="while_in_Large_form"/>
+
+
+      <uses fixed="1">
+
+
+        <recharge type="LR"/>
+
+
+      </uses>
+
+
+    </trait>
+    <trait category="species" name="Powerful Build">
+      <text>You have Advantage on any ability check you make to end the Grappled condition. You also count as one size larger when determining your carrying capacity.</text>
+
+
+      <effect type="Advantage" on="ability_checks_to_end_Grappled_condition"/>
+
+
+      <modifies_rule rule_name="CarryingCapacity" effect_description="Count as one size larger for determining carrying capacity."/>
+
+
+    </trait>
+  </race>
+  <race>
+    <name>Halfling [2024]</name>
+    <source page="193">Player's Handbook 2024</source>
+    <size_summary code="S"/>
+    <speed base="30"/>
+    <trait category="description" name="Description">
+      <text>Cherished and guided by gods who value life, home, and hearth, halflings gravitate toward bucolic havens where family and community help shape their lives. That said, many halflings possess a brave and adventurous spirit that leads them on journeys of discovery, affording them the chance to explore a bigger world and make new friends along the way. Their size -similar to that of a human child- helps them pass through crowds unnoticed and slip through tight spaces.
+	Anyone who has spent time around halflings, particularly halfling adventurers, has likely witnessed the storied &quot;luck of the halflings&quot; in action. When a halfling is in mortal danger, an unseen force seems to intervene on the halfling's behalf. Many halflings believe in the power of luck, and they attribute their unusual gift to one or more of their benevolent gods, including Yondalla, Brandobaris, and Charmalaine. The same gift might contribute to their robust life spans (about 150 years).
+	Halfling communities come in all varieties. For every sequestered shire tucked away in an unspoiled part of the world, there's a crime syndicate like the Boromar Clan in the Eberron setting or a territorial mob of halflings like those in the Dark Sun setting.
+	Halflings who prefer to live underground are sometimes called strongheart halflings or stouts. Nomadic halflings, as well as those who live among humans and other tall folk. are sometimes called lightfoot halflings or tallfellows.</text>
+
+
+    </trait>
+    <trait category="core" name="Creature Type">
+      <text>Humanoid</text>
+
+
+    </trait>
+    <trait category="core" name="Size">
+      <text>Small (about 2-3 feet tall)</text>
+
+
+      <effect type="SizeCategory" value="Small" description_text="about 2-3 feet tall"/>
+
+
+    </trait>
+    <trait category="species" name="Brave">
+      <text>You have Advantage on saving throws you make to avoid or end the Frightened condition.</text>
+
+
+      <effect type="Advantage" on="saving_throws_to_avoid_or_end_Frightened_condition"/>
+
+
+    </trait>
+    <trait category="species" name="Halfling Nimbleness">
+      <text>You can move through the space of any creature that is a size larger than you. but you can't stop in the same space.</text>
+
+
+      <modifies_rule rule_name="MovementThroughHostileSpace" effect_description="Can move through the space of any creature that is a size larger, but cannot stop there."/>
+
+
+    </trait>
+    <trait category="species" name="Luck">
+      <text>When you roll a 1 on the d20 of a D20 Test. you can reroll the die, and you must use the new roll.</text>
+
+
+      <reroll_option dice_condition="rolls_a_1" on_roll_for="any_D20_Test" must_use_new_roll="true"/>
+
+
+    </trait>
+    <trait category="species" name="Naturally Stealthy">
+      <text>You can take the Hide action even when you are obscured only by a creature that is at least one size larger than you.</text>
+
+
+      <modifies_action action_name="Hide" new_condition_text="Can Hide even when obscured only by a creature at least one size larger."/>
+
+
+    </trait>
+  </race>
+  <race>
+    <name>Human [2024]</name>
+    <source page="194">Player's Handbook 2024</source>
+    <size_summary code="M"/>
+    <speed base="30"/>
+    <trait category="description" name="Description">
+      <text>Found throughout the multiverse, humans are as varied as they are numerous, and they endeavor to achieve as much as they can in the years they are given. Their ambition and resourcefulness are commended, respected, and feared on many worlds.
+	Humans are as diverse in appearance as the people of Earth, and they have many gods. Scholars dispute the origin of humanity, but one of the earliest known human gatherings is said to have occurred in Sigil, the torus-shaped city at the center of the multiverse and the place where the Common language was born. From there, humans could have spread to every part of the multiverse, bringing the City of Doors' cosmopolitanism with them.</text>
+
+
+    </trait>
+    <trait category="core" name="Creature Type">
+      <text>Humanoid</text>
+
+
+    </trait>
+    <trait category="core" name="Size">
+      <text>Humans can be Medium (about 4-7 feet tall) or Small (about 2-4 feet tall).</text>
+
+
+      <choice name="SizeSelection" count="1">
+
+
+        <option name="Medium" description_text="about 4-7 feet tall">
+
+
+          <effect type="SizeCategory" value="Medium"/>
+
+
+        </option>
+
+
+        <option name="Small" description_text="about 2-4 feet tall">
+
+
+          <effect type="SizeCategory" value="Small"/>
+
+
+        </option>
+
+
+      </choice>
+
+
+      <note text="This choice is made when you select this species."/>
+
+
+    </trait>
+    <trait category="species" name="Resourceful">
+      <text>You gain Heroic Inspiration whenever you finish a Long Rest.</text>
+
+
+      <effect type="GainResource" resource_name="HeroicInspiration" timing="whenever_you_finish_a_Long_Rest"/>
+
+
+    </trait>
+    <trait category="species" name="Skillful">
+      <text>You gain proficiency in one skill of your choice.</text>
+
+
+      <grants_proficiency type="Skill" choice_from_list="any" count="1"/>
+
+
+    </trait>
+    <trait category="species" name="Versatile">
+      <text>You gain an Origin feat of your choice (see chapter 5). Skilled is recommended.</text>
+
+
+      <grants_feat type="OriginFeat" count="1" recommendation="Skilled"/>
+
+
+    </trait>
+  </race>
+  <race>
+    <name>Orc [2024]</name>
+    <source page="195">Player's Handbook 2024</source>
+    <size_summary code="M"/>
+    <speed base="30"/>
+    <trait category="description" name="Description">
+      <text>Ores trace their creation to Gruumsh, a powerful god who roamed the wide open spaces of the Material Plane. Gruumsh equipped his children with gifts to help them wander great plains, vast caverns, and churning seas and to face the monsters that lurk there. Even when they turn their devotion to other gods, ores retain Gruumsh's gifts: endurance, determination, and the ability to see in darkness.
+	Ores are, on average, tall and broad. They have gray skin, ears that are sharply pointed, and prominent lower canines that resemble small tusks. Ore youths on some worlds are told about their ancestors' great travels and travails. Inspired by those tales, many of those ores wonder when Gruumsh will call on them to match the heroic deeds of old and if they will prove worthy of his favor. Other ores are happy to leave old tales in the past and find their own way.</text>
+
+
+    </trait>
+    <trait category="core" name="Creature Type">
+      <text>Humanoid</text>
+
+
+    </trait>
+    <trait category="core" name="Size">
+      <text>Medium (about 6-7 feet tall)</text>
+
+
+      <effect type="SizeCategory" value="Medium" description_text="about 6-7 feet tall"/>
+
+
+    </trait>
+    <trait category="species" name="Adrenaline Rush">
+      <text>You can take the Dash action as a Bonus Action. When you do so, you gain a number of Temporary Hit Points equal to your Proficiency Bonus.</text>
+
+
+      <action_option name="AdrenalineRushDash">
+
+
+        <action type="BonusAction" name_override="Dash"/>
+
+
+        <effect type="GainTemporaryHitPoints" value_formula="ProficiencyBonus"/>
+
+
+      </action_option>
+
+
+      <uses attribute="ProficiencyBonus">
+
+
+        <recharge type="SR_or_LR"/>
+
+
+      </uses>
+
+
+    </trait>
+    <trait category="species" name="Darkvision">
+      <text>You have Darkvision with a range of 120 feet.</text>
+
+
+      <effect type="Sense" name="Darkvision" range="120"/>
+
+
+    </trait>
+    <trait category="species" name="Relentless Endurance">
+      <text>When you are reduced to 0 Hit Points but not killed outright. you can drop to 1 Hit Point instead. Once you use this trait, you can't do so again until you finish a Long Rest.</text>
+
+
+      <trigger text="when_reduced_to_0_HP_but_not_killed_outright"/>
+
+
+      <effect type="SetHitPoints" value="1"/>
+
+
+      <uses fixed="1">
+
+
+        <recharge type="LR"/>
+
+
+      </uses>
+
+
+    </trait>
+  </race>
+  <race>
+    <name>Tiefling, Abyssal [2024]</name>
+    <source page="196">Player's Handbook 2024</source>
+    <size_summary code="M"/>
+    <speed base="30"/>
+    <trait category="description" name="Description">
+      <text>Tieflings are either born in the Lower Planes or have fiendish ancestors who originated there. A tiefling (pronounced TEE-fling) is linked by blood to a devil, a demon, or some other Fiend. This connection to the Lower Planes is the tiefling's fiendish legacy, which comes with the promise of power yet has no effect on the tiefling's moral outlook.
+
+The entropy of the Abyss, the chaos of Pandemonium, and the despair of Carceri call to tieflings who have the abyssal legacy. Horns, fur, tusks, and peculiar scents are common physical features of such tieflings, most of whom have the blood of demons coursing through their veins.</text>
+
+
+    </trait>
+    <trait category="core" name="Creature Type">
+      <text>Humanoid</text>
+
+
+    </trait>
+    <trait category="core" name="Size">
+      <text>Tieflings can be Medium (about 4-7 feet tall) or Small (about 3-4 feet tall).</text>
+
+
+      <choice name="SizeSelection" count="1">
+
+
+        <option name="Medium" description_text="about 4-7 feet tall">
+
+
+          <effect type="SizeCategory" value="Medium"/>
+
+
+        </option>
+
+
+        <option name="Small" description_text="about 3-4 feet tall">
+
+
+          <effect type="SizeCategory" value="Small"/>
+
+
+        </option>
+
+
+      </choice>
+
+
+      <note text="This choice is made when you select this species."/>
+
+
+    </trait>
+    <trait category="species" name="Darkvision">
+      <text>You have Darkvision with a range of 60 feet.</text>
+
+
+      <effect type="Sense" name="Darkvision" range="60"/>
+
+
+    </trait>
+    <trait category="lineage" name="Fiendish Legacy (Abyssal)">
+      <text>You have Resistance to Poison damage. You also know the Poison Spray cantrip. Intelligence, Wisdom, or Charisma is your spellcasting ability for the spells you cast with this trait (choose the ability when you select the legacy).</text>
+
+
+      <effect type="Resistance" damage_types="Poison"/>
+
+
+      <grants_spell_learning type="Cantrip" spell_known="Poison Spray" spellcasting_ability_choice="Intelligence|Wisdom|Charisma" count="1"/>
+
+
+      <grants_spell_learning type="Spell" spell_known="Ray of Sickness" gained_at_character_level="3" spellcasting_ability_choice_ref="Fiendish Legacy (Abyssal)" free_casts_per_rest="LongRest" count="1"/>
+
+
+      <grants_spell_learning type="Spell" spell_known="Hold Person" gained_at_character_level="5" spellcasting_ability_choice_ref="Fiendish Legacy (Abyssal)" free_casts_per_rest="LongRest" count="1"/>
+
+
+    </trait>
+    <trait category="species" name="Otherworldly Presence">
+      <text>You know the Thaumaturgy cantrip. When you cast it with this trait, the spell uses the same spellcasting ability you use for your Fiendish Legacy trait.</text>
+
+
+      <grants_spell_learning type="Cantrip" spell_known="Thaumaturgy" spellcasting_ability_choice_ref="Fiendish Legacy (Abyssal)"/>
+
+
+    </trait>
+  </race>
+  <race>
+    <name>Tiefling, Chthonic [2024]</name>
+    <source page="196">Player's Handbook 2024</source>
+    <size_summary code="M"/>
+    <speed base="30"/>
+    <trait category="description" name="Description">
+      <text>Tieflings are either born in the Lower Planes or have fiendish ancestors who originated there. A tiefling (pronounced TEE-fling) is linked by blood to a devil, a demon, or some other Fiend. This connection to the Lower Planes is the tiefling's fiendish legacy, which comes with the promise of power yet has no effect on the tiefling's moral outlook.
+
+Tieflings who have the chthonic legacy feel not only the tug of Carceri but also the greed of Gehenna and the gloom of Hades. Some of these tieflings look cadaverous. Others possess the unearthly beauty of a succubus, or they have physical features in common with a night hag, a yugoloth, or some other Neutral Evil fiendish ancestor.</text>
+
+
+    </trait>
+    <trait category="core" name="Creature Type">
+      <text>Humanoid</text>
+
+
+    </trait>
+    <trait category="core" name="Size">
+      <text>Tieflings can be Medium (about 4-7 feet tall) or Small (about 3-4 feet tall).</text>
+
+
+      <choice name="SizeSelection" count="1">
+
+
+        <option name="Medium" description_text="about 4-7 feet tall">
+
+
+          <effect type="SizeCategory" value="Medium"/>
+
+
+        </option>
+
+
+        <option name="Small" description_text="about 3-4 feet tall">
+
+
+          <effect type="SizeCategory" value="Small"/>
+
+
+        </option>
+
+
+      </choice>
+
+
+      <note text="This choice is made when you select this species."/>
+
+
+    </trait>
+    <trait category="species" name="Darkvision">
+      <text>You have Darkvision with a range of 60 feet.</text>
+
+
+      <effect type="Sense" name="Darkvision" range="60"/>
+
+
+    </trait>
+    <trait category="lineage" name="Fiendish Legacy (Chthonic)">
+      <text>You have Resistance to Necrotic damage. You also know the Chill Touch cantrip. Intelligence, Wisdom, or Charisma is your spellcasting ability for the spells you cast with this trait (choose the ability when you select the legacy).</text>
+
+
+      <effect type="Resistance" damage_types="Necrotic"/>
+
+
+      <grants_spell_learning type="Cantrip" spell_known="Chill Touch" spellcasting_ability_choice="Intelligence|Wisdom|Charisma" count="1"/>
+
+
+      <grants_spell_learning type="Spell" spell_known="False Life" gained_at_character_level="3" spellcasting_ability_choice_ref="Fiendish Legacy (Chthonic)" free_casts_per_rest="LongRest" count="1"/>
+
+
+      <grants_spell_learning type="Spell" spell_known="Ray of Enfeeblement" gained_at_character_level="5" spellcasting_ability_choice_ref="Fiendish Legacy (Chthonic)" free_casts_per_rest="LongRest" count="1"/>
+
+
+    </trait>
+    <trait category="species" name="Otherworldly Presence">
+      <text>You know the Thaumaturgy cantrip. When you cast it with this trait, the spell uses the same spellcasting ability you use for your Fiendish Legacy trait.</text>
+
+
+      <grants_spell_learning type="Cantrip" spell_known="Thaumaturgy" spellcasting_ability_choice_ref="Fiendish Legacy (Chthonic)"/>
+
+
+    </trait>
+  </race>
+  <race>
+    <name>Tiefling, Infernal [2024]</name>
+    <source page="196">Player's Handbook 2024</source>
+    <size_summary code="M"/>
+    <speed base="30"/>
+    <trait category="description" name="Description">
+      <text>Tieflings are either born in the Lower Planes or have fiendish ancestors who originated there. A tiefling (pronounced TEE-fling) is linked by blood to a devil, a demon, or some other Fiend. This connection to the Lower Planes is the tiefling's fiendish legacy, which comes with the promise of power yet has no effect on the tiefling's moral outlook.
+
+The infernal legacy connects tieflings not only to Gehenna but also the Nine Hells and the raging battlefields of Acheron. Horns, spines, tails, golden eyes, and a faint odor of sulfur or smoke are common physical features of such tieflings, most of whom trace their ancestry to devils.</text>
+
+
+    </trait>
+    <trait category="core" name="Creature Type">
+      <text>Humanoid</text>
+
+
+    </trait>
+    <trait category="core" name="Size">
+      <text>Tieflings can be Medium (about 4-7 feet tall) or Small (about 3-4 feet tall).</text>
+
+
+      <choice name="SizeSelection" count="1">
+
+
+        <option name="Medium" description_text="about 4-7 feet tall">
+
+
+          <effect type="SizeCategory" value="Medium"/>
+
+
+        </option>
+
+
+        <option name="Small" description_text="about 3-4 feet tall">
+
+
+          <effect type="SizeCategory" value="Small"/>
+
+
+        </option>
+
+
+      </choice>
+
+
+      <note text="This choice is made when you select this species."/>
+
+
+    </trait>
+    <trait category="species" name="Darkvision">
+      <text>You have Darkvision with a range of 60 feet.</text>
+
+
+      <effect type="Sense" name="Darkvision" range="60"/>
+
+
+    </trait>
+    <trait category="lineage" name="Fiendish Legacy (Infernal)">
+      <text>You have Resistance to Fire damage. You also know the Fire Bolt cantrip. Intelligence, Wisdom, or Charisma is your spellcasting ability for the spells you cast with this trait (choose the ability when you select the legacy).</text>
+
+
+      <effect type="Resistance" damage_types="Fire"/>
+
+
+      <grants_spell_learning type="Cantrip" spell_known="Fire Bolt" spellcasting_ability_choice="Intelligence|Wisdom|Charisma" count="1"/>
+
+
+      <grants_spell_learning type="Spell" spell_known="Hellish Rebuke" gained_at_character_level="3" spellcasting_ability_choice_ref="Fiendish Legacy (Infernal)" free_casts_per_rest="LongRest" count="1"/>
+
+
+      <grants_spell_learning type="Spell" spell_known="Darkness" gained_at_character_level="5" spellcasting_ability_choice_ref="Fiendish Legacy (Infernal)" free_casts_per_rest="LongRest" count="1"/>
+
+
+    </trait>
+    <trait category="species" name="Otherworldly Presence">
+      <text>You know the Thaumaturgy cantrip. When you cast it with this trait, the spell uses the same spellcasting ability you use for your Fiendish Legacy trait.</text>
+
+
+      <grants_spell_learning type="Cantrip" spell_known="Thaumaturgy" spellcasting_ability_choice_ref="Fiendish Legacy (Infernal)"/>
+
+
+    </trait>
+  </race>
+</compendium>


### PR DESCRIPTION
- Created `parse_races.py` to read `races-phb24.xml`.
- The script restructures top-level race elements according to glossary specifications.
- It preserves the detailed structure within `<trait>` elements, as the input file's tags and nesting already align with the glossary.
- Added `races-phb24-parsed.xml` which is the output of this script.