### PR TITLE
Fix XML parsing errors in PHB24 class and feat files

### DIFF
--- a/01_Core/classes/class-fighter-phb24.xml
+++ b/01_Core/classes/class-fighter-phb24.xml
@@ -478,8 +478,10 @@ Source:	Player's Handbook 2024 p. 94</text>
     </autolevel>
     <autolevel level="18">
       <feature optional="YES">
-        <!-- Name tag removed for testing parser error -->
-        <text>Your Superiority Die becomes a d12.&#10;Source: Player's Handbook 2024 p. 94</text>
+        <name>Level 18: Ultimate Combat Superiority (Battle Master)</name>
+        <text>Your Superiority Die becomes a d12.
+
+Source:	Player's Handbook 2024 p. 94</text>
         <subclass>Battle Master</subclass>
         <modifies_resource name="SuperiorityDice" new_die_type="d12"/>
       </feature>

--- a/01_Core/classes/class-ranger-phb24.xml
+++ b/01_Core/classes/class-ranger-phb24.xml
@@ -783,7 +783,6 @@ Source:	Player's Handbook 2024 p. 126</text>
         <alternative_grant condition="if_already_proficient_in_Wisdom_saves">
           <grants_proficiency type="SavingThrow" choice_from_list="Intelligence,Charisma" count="1"/>
         </alternative_grant>
-        <proficiency>wisdom</proficiency> <!-- Original tag -->
       </feature>
     </autolevel>
     <autolevel level="11">

--- a/01_Core/classes/class-wizard-phb24.xml
+++ b/01_Core/classes/class-wizard-phb24.xml
@@ -739,12 +739,6 @@ Source:	Player's Handbook 2024 p. 175</text>
           </can_cast_without_slot>
         </modifies_spell>
       </feature>
-      <counter>
-        <name>Phantasmal Creatures</name>
-        <value>1</value>
-        <reset>L</reset>
-        <subclass>Illusionist</subclass>
-      </counter>
     </autolevel>
     <autolevel level="10">
       <feature optional="YES">

--- a/01_Core/feats/feats-phb24.xml
+++ b/01_Core/feats/feats-phb24.xml
@@ -2143,8 +2143,7 @@
             <description>As a Bonus Action, you can telekinetically shove one creature you can see within 30 feet of yourself. When you do so, the target must succeed on a Strength saving throw (DC 8 plus Intelligence modifier and your Proficiency Bonus) or be moved 5 feet toward or away from you.</description>
             <target description="one creature you can see"/>
             <effect type="Movement" value="5_feet" direction_choice="toward_you|away_from_you">
-                <save type="Strength" dc_formula="8 + Intelligence_modifier + ProficiencyBonus"/>
-                <on_successful_save description="Target is not moved."/>
+                <save type="Strength" dc_formula="8 + Intelligence_modifier + ProficiencyBonus" effect_on_success="Target is not moved."/>
             </effect>
         </action_option>
     </benefit>


### PR DESCRIPTION
Corrected several XML parsing and structural issues in class and feat files based on glossary_xml_tags_v1.txt and original PHB24 source files.

Changes include:
- Added missing <name> tag in class-fighter-phb24.xml.
- Removed redundant <proficiency> tag in class-ranger-phb24.xml.
- Confirmed sorcerer and warlock files were already correct regarding specific reported counter issues.
- Removed redundant <counter> in class-wizard-phb24.xml where uses were already defined.
- Adjusted <on_successful_save> to be an attribute effect_on_success within <save> tag in feats-phb24.xml for Telekinetic feat.